### PR TITLE
Update MaxSizes.cfg

### DIFF
--- a/GameData/SSTU-NovaPack/Data/MaxSizes.cfg
+++ b/GameData/SSTU-NovaPack/Data/MaxSizes.cfg
@@ -1,20 +1,12 @@
-PARTUPGRADE
+@PARTUPGRADE[SSTU-DC-D5]
 {
-	name = SSTU-DC-D5
-	partIcon = SSTU-SC-GEN-PDC
-	techRequired = experimentalRocketry
-	entryCost = 80000
-	title = Modular Decoupler Max Diameter Increase (20m)
-	description = Increases the maximum diameter available for Modular Decouplers.  This upgrade allows up to 20m diameter decouplers to be created.
+	@title = Modular Decoupler Max Diameter Increase (20m)
+	@description = Increases the maximum diameter available for Modular Decouplers.  This upgrade allows up to 20m diameter decouplers to be created.
 }
-PARTUPGRADE
+@PARTUPGRADE[SSTU-FR-D5]
 {
-	name = SSTU-FR-D5
-	partIcon = SSTU-SC-GEN-FR-N
-	techRequired = experimentalRocketry
-	entryCost = 80000
-	title = Modular Fairing Max Diameter Increase (20m)
-	description = Increases the maximum diameter available for modular fairings.  This upgrade allows up to 20m diameter fairings to be created.
+	@title = Modular Fairing Max Diameter Increase (20m)
+	@description = Increases the maximum diameter available for modular fairings.  This upgrade allows up to 20m diameter fairings to be created.
 }
 @PARTUPGRADE[SSTU-MFT-D6]
 {

--- a/GameData/SSTU-NovaPack/Data/MaxSizes.cfg
+++ b/GameData/SSTU-NovaPack/Data/MaxSizes.cfg
@@ -38,138 +38,126 @@ PARTUPGRADE
 {
 	@MODULE[SSTUCustomRadialDecoupler]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D1]]
 			{
-				name__ = SSTU-DC-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D2]]
 			{
-				name__ = SSTU-DC-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D3]]
 			{
-				name__ = SSTU-DC-D3
-				maxDiameter = 6.25
+				@maxDiameter = 5.0
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D4]]
 			{
-				name__ = SSTU-DC-D4
+				@maxDiameter = 6.25
+			}
+			@UPGRADE:HAS[#name__[SSTU-DC-D5]]
+			{
 				maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D6]]
 			{
-				name__ = SSTU-DC-D5
 				maxDiameter = 20
 			}
-		}	
+		}
 	}
 }
 @PART[*]:HAS[@MODULE[SSTUProceduralDecoupler]]:NEEDS[SSTU]
 {
 	@MODULE[SSTUProceduralDecoupler]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D1]]
 			{
-				name__ = SSTU-DC-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D2]]
 			{
-				name__ = SSTU-DC-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D3]]
 			{
-				name__ = SSTU-DC-D3
-				maxDiameter = 6.25
+				@maxDiameter = 5.0
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D4]]
 			{
-				name__ = SSTU-DC-D4
+				@maxDiameter = 6.25
+			}
+			@UPGRADE:HAS[#name__[SSTU-DC-D5]]
+			{
 				maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D6]]
 			{
-				name__ = SSTU-DC-D5
 				maxDiameter = 20
 			}
-		}	
+		}
 	}
 }
 @PART[*]:HAS[@MODULE[SSTUInterstageDecoupler]]:NEEDS[SSTU]
 {
 	@MODULE[SSTUInterstageDecoupler]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D1]]
 			{
-				name__ = SSTU-DC-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D2]]
 			{
-				name__ = SSTU-DC-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D3]]
 			{
-				name__ = SSTU-DC-D3
-				maxDiameter = 6.25
+				@maxDiameter = 5.0
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D4]]
 			{
-				name__ = SSTU-DC-D4
+				@maxDiameter = 6.25
+			}
+			@UPGRADE:HAS[#name__[SSTU-DC-D5]]
+			{
 				maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-DC-D6]]
 			{
-				name__ = SSTU-DC-D5
 				maxDiameter = 20
 			}
-		}	
+		}
 	}
 }
 @PART[*]:HAS[@MODULE[SSTUInterstageFairing]]:NEEDS[SSTU]
 {
 	@MODULE[SSTUInterstageFairing]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D1]]
 			{
-				name__ = SSTU-FR-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D2]]
 			{
-				name__ = SSTU-FR-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D3]]
 			{
-				name__ = SSTU-FR-D3
-				maxDiameter = 6.25
+				@maxDiameter = 6.25
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D4]]
 			{
-				name__ = SSTU-FR-D4
-				maxDiameter = 10
+				@maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D5]]
 			{
-				name__ = SSTU-FR-D5
-				maxDiameter = 20
+				@maxDiameter = 20
 			}
 		}	
 	}
@@ -178,33 +166,27 @@ PARTUPGRADE
 {
 	@MODULE[SSTUResizableFairing]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D1]]
 			{
-				name__ = SSTU-FR-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D2]]
 			{
-				name__ = SSTU-FR-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D3]]
 			{
-				name__ = SSTU-FR-D3
-				maxDiameter = 6.25
+				@maxDiameter = 6.25
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D4]]
 			{
-				name__ = SSTU-FR-D4
-				maxDiameter = 10
+				@maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D5]]
 			{
-				name__ = SSTU-FR-D5
-				maxDiameter = 20
+				@maxDiameter = 20
 			}
 		}	
 	}
@@ -213,33 +195,27 @@ PARTUPGRADE
 {
 	@MODULE[SSTUModularHeatShield]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D1]]
 			{
-				name__ = SSTU-FR-D1
-				maxDiameter = 2.5
+				@maxDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D2]]
 			{
-				name__ = SSTU-FR-D2
-				maxDiameter = 3.75
+				@maxDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D3]]
 			{
-				name__ = SSTU-FR-D3
-				maxDiameter = 6.25
+				@maxDiameter = 6.25
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D4]]
 			{
-				name__ = SSTU-FR-D4
-				maxDiameter = 10
+				@maxDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-FR-D5]]
 			{
-				name__ = SSTU-FR-D5
-				maxDiameter = 20
+				@maxDiameter = 20
 			}
 		}	
 	}
@@ -248,43 +224,31 @@ PARTUPGRADE
 {
 	@MODULE[SSTUCustomUpperStage]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D1]]
 			{
-				name__ = SSTU-MFT-D1
-				maxTankDiameter = 1.875
+				@maxTankDiameter = 1.875
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D2]]
 			{
-				name__ = SSTU-MFT-D2
-				maxTankDiameter = 2.5
+				@maxTankDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D3]]
 			{
-				name__ = SSTU-MFT-D3
-				maxTankDiameter = 3.125
+				@maxTankDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D4]]
 			{
-				name__ = SSTU-MFT-D4
-				maxTankDiameter = 3.75
+				@maxTankDiameter = 5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D5]]
 			{
-				name__ = SSTU-MFT-D5
-				maxTankDiameter = 6.25
+				@maxTankDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D6]]
 			{
-				name__ = SSTU-MFT-D6
-				maxTankDiameter = 20
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MFT-M1
-				minTankDiameter = 0.625
+				@maxTankDiameter = 20
 			}
 		}
 	}
@@ -294,47 +258,35 @@ PARTUPGRADE
 		%maxBottomDiameter = 20
 	}
 }
-@PART[*]:HAS[@MODULE[SSTUModularFuelTank]]:NEEDS[SSTU]
+@PART[*]:HAS[@MODULE[SSTUModularFuelTank]:HAS[!TANK[MFT-R*]]]:NEEDS[SSTU]
 {
 	@MODULE[SSTUModularFuelTank]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D1]]
 			{
-				name__ = SSTU-MFT-D1
-				maxTankDiameter = 1.875
+				@maxTankDiameter = 1.875
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D2]]
 			{
-				name__ = SSTU-MFT-D2
-				maxTankDiameter = 2.5
+				@maxTankDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D3]]
 			{
-				name__ = SSTU-MFT-D3
-				maxTankDiameter = 3.125
+				@maxTankDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D4]]
 			{
-				name__ = SSTU-MFT-D4
-				maxTankDiameter = 3.75
+				@maxTankDiameter = 5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D5]]
 			{
-				name__ = SSTU-MFT-D5
-				maxTankDiameter = 6.25
+				@maxTankDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D6]]
 			{
-				name__ = SSTU-MFT-D6
-				maxTankDiameter = 20
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MFT-M1
-				minTankDiameter = 0.625
+				@maxTankDiameter = 20
 			}
 		}
 	}
@@ -343,43 +295,31 @@ PARTUPGRADE
 {
 	@MODULE[SSTUModularCargoBay]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D1]]
 			{
-				name__ = SSTU-MFT-D1
-				maxTankDiameter = 1.875
+				@maxTankDiameter = 1.875
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D2]]
 			{
-				name__ = SSTU-MFT-D2
-				maxTankDiameter = 2.5
+				@maxTankDiameter = 2.5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D3]]
 			{
-				name__ = SSTU-MFT-D3
-				maxTankDiameter = 3.125
+				@maxTankDiameter = 3.75
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D4]]
 			{
-				name__ = SSTU-MFT-D4
-				maxTankDiameter = 3.75
+				@maxTankDiameter = 5
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D5]]
 			{
-				name__ = SSTU-MFT-D5
-				maxTankDiameter = 6.25
+				@maxTankDiameter = 10
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MFT-D6]]
 			{
-				name__ = SSTU-MFT-D6
-				maxTankDiameter = 20
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MFT-M1
-				minTankDiameter = 0.625
+				@maxTankDiameter = 20
 			}
 		}
 	}
@@ -388,33 +328,11 @@ PARTUPGRADE
 {
 	@MODULE[SSTUModularBooster]
 	{
-		!UPGRADES{}
-		UPGRADES
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[SSTU-MSRB-D5]]
 			{
-				name__ = SSTU-MSRB-D1
-				maxDiameter = 1.875
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MSRB-D2
-				maxDiameter = 2.5
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MSRB-D3
-				maxDiameter = 3.125
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MSRB-D4
-				maxDiameter = 3.75
-			}
-			UPGRADE
-			{
-				name__ = SSTU-MSRB-D5
-				maxDiameter = 10
+				@maxDiameter = 10
 			}
 		}	
 	}


### PR DESCRIPTION
Patches UPGRADE nodes instead of deleting and replacing them. (this was causing issues where certain UPGRADE nodes were deleted and  not being replaced resulting in not being able to properly edit SRB lengths and variants in the VAB/SPH)